### PR TITLE
Specify no wrap for search()

### DIFF
--- a/plugin/vim-mysql-plugin.vim
+++ b/plugin/vim-mysql-plugin.vim
@@ -68,8 +68,8 @@ func! g:DescriptCursorTable()
 endfun
 
 fun! g:RunInstruction()
-	let l:PrevSemicolon = search(';', 'bn')
-	let l:NextSemicolon = search(';', 'n')
+	let l:PrevSemicolon = search(';', 'bnW')
+	let l:NextSemicolon = search(';', 'nW')
 	let l:Lines = getline(l:PrevSemicolon, l:NextSemicolon)[1:]
 	let l:Lines = map(l:Lines, "substitute(v:val, '--.*$', '', 'g')")
 	let l:CurrentInstruction = join(l:Lines, ' ')


### PR DESCRIPTION
The `search()` commands were not specifying whether to wrap around the start/end of the file.

This meant, in my environment, that the backwards search for the semicolon was wrapping around and finding the end one. Therefore `\rr` submitted an empty string to MySQL.

By adding the `W` flag to the searches we ensure that searchwrap does not apply.