### PR TITLE
Fix missing escaping of shell characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ call vundle#end()
 
 And remember to execute `:PluginInstall` in VIM normal mode.
 
+- Plug (for neovim)
+
+Add the following to `~/.config/nvim/init.vim`:
+```vimrc
+" ... some other configurations
+Plugin 'https://github.com/kezhenxu94/vim-mysql-plugin.git'
+" ... some other configurations
+```
+
+Then run `:PlugInstall`.
+
+
 ## How does it work
 
 For the sake of security and convenience, this plugin utilizes a command line parameter of MySQL client called `defaults-group-suffix`, for more details about `defaults-group-suffix`, check out the documentation [here](https://dev.mysql.com/doc/refman/5.5/en/option-file-options.html#option_general_defaults-group-suffix); but now just put your configuration in the file `~/.my.cnf` like this:
@@ -51,6 +63,19 @@ default_character_set = utf8
 database = mysql
 ```
 
+**Note**: if you already use `.my.cnf`, then add the new contents at the end. As your configuration options will be read after the main `[Client]` ones, you do not need to repeat those if the values are the same, for example, to set up a section for a particular database using your normal credials, your `.my.cnf` might look like this:
+
+```conf
+[client]
+user = mymysqlmamaria
+password = neveryoumind
+
+# ↑ that config was there before
+# ↓ this config is what we added
+[client-mydb]
+database = mydb
+```
+
 ## Usage
 
 Create a new file whose name ends with `.sql`, adding the following two lines in the very beginning of the file:
@@ -68,6 +93,8 @@ Then add your sql statements following the two lines. Here is a sample of the `s
    
 select * from user;
 ```
+
+**Note**: The `--default-group-suffix` option is a *suffix*, i.e. we're entering `ExampleTest` not `ClientExampleTest`. To use the 2nd configuration example you'd use `--default-group-suffix=mydb`.
 
 - Move the caret to the line `select * from user;` and type `<leader>rr` in VIM normal mode to run the line;
 

--- a/plugin/vim-mysql-plugin.vim
+++ b/plugin/vim-mysql-plugin.vim
@@ -56,14 +56,14 @@ endf
 func! g:SelectCursorTable()
 	let l:Table = '`' . expand('<cword>') . '`'
 	let l:Command = s:GetCommand() . ' -e ' . '"select * from ' . l:Table . '"'
-	let l:Command = escape(l:Command, '%#\`')
+	let l:Command = escape(l:Command, '$!%#\`')
 	call g:RunShellCommand(l:Command)
 endfun
 
 func! g:DescriptCursorTable()
 	let l:Table = '`' . expand('<cword>') . '`'
 	let l:Command = s:GetCommand() . ' -e ' . '"show full columns from ' . l:Table . '"'
-	let l:Command = escape(l:Command, '%#\`')
+	let l:Command = escape(l:Command, '$!%#\`')
 	call g:RunShellCommand(l:Command)
 endfun
 
@@ -74,7 +74,7 @@ fun! g:RunInstruction()
 	let l:Lines = map(l:Lines, "substitute(v:val, '--.*$', '', 'g')")
 	let l:CurrentInstruction = join(l:Lines, ' ')
 	let l:Command = s:GetCommand() . ' -e "' . l:CurrentInstruction . '"'
-	let l:Command = escape(l:Command, '%#\`')
+	let l:Command = escape(l:Command, '$!%#\`')
 	call g:RunShellCommand(l:Command)
 endfun
 

--- a/plugin/vim-mysql-plugin.vim
+++ b/plugin/vim-mysql-plugin.vim
@@ -46,7 +46,7 @@ fun! g:RunSelection()
 		echohl Error | echon 'Nothing Selected' | echohl None
 		return
 	endif
-	call writefile(l:Selection, '/tmp/vim-mysql-plugin.sql', 'w')
+	call writefile(l:Selection, '/tmp/vim-mysql-plugin.sql')
 
 	let l:Command = s:GetCommand() . ' < ' . '/tmp/vim-mysql-plugin.sql'
 	let l:Command = escape(l:Command, '%#\`')

--- a/plugin/vim-mysql-plugin.vim
+++ b/plugin/vim-mysql-plugin.vim
@@ -68,8 +68,8 @@ func! g:DescriptCursorTable()
 endfun
 
 fun! g:RunInstruction()
-	let l:PrevSemicolon = search(';', 'bn')
-	let l:NextSemicolon = search(';', 'n')
+	let l:PrevSemicolon = search(';', 'bnW')
+	let l:NextSemicolon = search(';', 'nW')
 	let l:Lines = getline(l:PrevSemicolon, l:NextSemicolon)[1:]
 	let l:Lines = map(l:Lines, "substitute(v:val, '--.*$', '', 'g')")
 	let l:CurrentInstruction = join(l:Lines, ' ')


### PR DESCRIPTION
I had an SQL statement with an exclamation mark in it and it was behaving weirdly because it was not escaped.

I assume the same would be true of $ since you're using "". I added these to the escape commands when the statement is passed via -e