### PR TITLE
Refactor + security improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,33 +74,41 @@ password = neveryoumind
 
 # ↑ that config was there before
 # ↓ this config is what we added
-[client-mydb]
+[clientMyDb]
 database = mydb
 ```
 
 ## Usage
 
-Create a new file whose name ends with `.sql`, adding the following two lines in the very beginning of the file:
+Create a new file whose name ends with `.sql`, adding the following three lines in the very beginning of the file:
 
 ```sql
--- --defaults-group-suffix=ExampleTest -t
+-- --defaults-group-suffix=ExampleTest
+-- -t
 --
 ```
 
-Then add your sql statements following the two lines. Here is a sample of the `sql` file:
+Notes:
+
+- The first line with `--default-group-suffix` identifies the configuration **suffix**, defined above. i.e. we're entering `ExampleTest` not `ClientExampleTest`. To use the 2nd configuration example you'd use `--default-group-suffix=MyDb`.
+
+- The -t option means output as a table. You can ommit this if you want bare output.
+
+- Each mysql option **must** be on its own line.
+
+Then add your sql statements following the three lines. Here is a sample of the `sql` file:
 
 ```sql
--- --defaults-group-suffix=ExampleTest -t
+-- --defaults-group-suffix=ExampleTest
+-- -t
 --
-   
-select * from user;
-```
 
-**Note**: The `--default-group-suffix` option is a *suffix*, i.e. we're entering `ExampleTest` not `ClientExampleTest`. To use the 2nd configuration example you'd use `--default-group-suffix=mydb`.
+SELECT * FROM USER;
+```
 
 - Move the caret to the line `select * from user;` and type `<leader>rr` in VIM normal mode to run the line;
 
-- Move the caret to the table name (such as `user`) and type `<leader>ds` (stands for "Describe") to show the columns of the table, type `<leader>ss` to `select *` from the table;
+- Move the caret to the table name (such as `user`) and type `<leader>ds` (stands for "Descript") to show the columns of the table, type `<leader>ss` to `SELECT *` from the table;
 
 - Using VIM visual mode to select a range of statement and type `<leader>rs` to execute the selected statements;
 
@@ -116,6 +124,14 @@ If you find it difficult to use this plugin, please open issues or help to impro
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars3.githubusercontent.com/u/15965696?v=4" width="50px;"/><br /><sub><b>kezhenxu94</b></sub>](https://kezhenxu94.me)<br />[💻](https://github.com/kezhenxu94/vim-mysql-plugin/commits?author=kezhenxu94 "Code") | [<img src="https://avatars2.githubusercontent.com/u/13188781?v=4" width="50px;"/><br /><sub><b>jfecher</b></sub>](http://antelang.org/)<br />[💻](https://github.com/kezhenxu94/vim-mysql-plugin/commits?author=jfecher "Code") |
+| [<img src="https://avatars3.githubusercontent.com/u/15965696?v=4" width="50px;"/><br /><sub><b>kezhenxu94</b></sub>](https://kezhenxu94.me)<br />[💻](https://github.com/kezhenxu94/vim-mysql-plugin/commits?author=kezhenxu94 "Code") | [<img src="https://avatars2.githubusercontent.com/u/13188781?v=4" width="50px;"/><br /><sub><b>jfecher</b></sub>](http://antelang.org/)<br />[💻](https://github.com/kezhenxu94/vim-mysql-plugin/commits?author=jfecher "Code")<br />[Artful Robot](https://artfulrobot.uk) |
 | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+## Change log
+
+- Security improvement: all shell commands are escaped with shellescape(). This means MySQL command options must now be one-per-line.
+
+- Security improvement: Previously SQL with double quotes `"` that was run with `<Leader>rr` would escape the shell argument, meaning the following code was run in the shell(!). This would potentially do very bad things.
+
+- Code refactor: all SQL execution now uses the same method (write it to a /tmp file and `<` redirect it into the command; we no longer use `-e` with SQL on the command line)

--- a/README.md
+++ b/README.md
@@ -135,3 +135,5 @@ If you find it difficult to use this plugin, please open issues or help to impro
 - Security improvement: Previously SQL with double quotes `"` that was run with `<Leader>rr` would escape the shell argument, meaning the following code was run in the shell(!). This would potentially do very bad things.
 
 - Code refactor: all SQL execution now uses the same method (write it to a /tmp file and `<` redirect it into the command; we no longer use `-e` with SQL on the command line)
+
+- Timings: An additional query is run to report on the execution time.

--- a/plugin/vim-mysql-plugin.vim
+++ b/plugin/vim-mysql-plugin.vim
@@ -46,11 +46,11 @@ fun! g:RunArray(sqlarray, timing)
 		return
 	endif
 
-  if a:timing
-    let l:thesql = ['SELECT NOW(3)+0 INTO @startTime;'] + a:sqlarray + ['SELECT CONCAT(ROUND(NOW(3) - @startTime, 3), "s") Took']
-  else
-    let l:thesql = a:sqlarray
-  endif
+	if a:timing
+		let l:thesql = ['SELECT NOW(3)+0 INTO @startTime;'] + a:sqlarray + ['SELECT CONCAT(ROUND(NOW(3) - @startTime, 3), "s") Took']
+	else
+		let l:thesql = a:sqlarray
+	endif
 	call writefile(l:thesql, '/tmp/vim-mysql-plugin.sql')
 	let l:Command = s:GetCommand() . ' </tmp/vim-mysql-plugin.sql'
 	call g:RunShellCommand(l:Command)
@@ -58,7 +58,7 @@ endf
 
 fun! g:RunSelection()
 	let l:Selection = g:GetSelection()
-  call g:RunArray(l:Selection, 1)
+	call g:RunArray(l:Selection, 1)
 endfun
 
 

--- a/plugin/vim-mysql-plugin.vim
+++ b/plugin/vim-mysql-plugin.vim
@@ -64,19 +64,19 @@ endfun
 
 func! g:SelectCursorTable()
 	let l:Table = expand('<cword>')
-  call RunArray(['SELECT * FROM `' . l:Table . '` LIMIT 100;'], 0)
+	call RunArray(['SELECT * FROM `' . l:Table . '` LIMIT 100;'], 0)
 endfun
 
 func! g:DescriptCursorTable()
 	let l:Table = expand('<cword>')
-  call RunArray(['SHOW FULL COLUMNS FROM `' . l:Table . '`;'], 0)
+	call RunArray(['SHOW FULL COLUMNS FROM `' . l:Table . '`;'], 0)
 endfun
 
 fun! g:RunInstruction()
 	let l:PrevSemicolon = search(';', 'bnW')
 	let l:NextSemicolon = search(';', 'nW')
 	let l:Lines = getline(l:PrevSemicolon, l:NextSemicolon)[1:]
-  call g:RunArray(l:Lines, 1)
+	call g:RunArray(l:Lines, 1)
 endfun
 
 fun! s:GetCommand()


### PR DESCRIPTION
This makes quite a few changes to the code to tighten up security: using `shellescape` for all shell arguments; always writing SQL to temp file; reduce different calling methods to reduce maintenance. See changes listed in README.