### PR TITLE
Bugfix: Options string not constructed correctly

### DIFF
--- a/plugin/vim-mysql-plugin.vim
+++ b/plugin/vim-mysql-plugin.vim
@@ -114,7 +114,7 @@ fun! s:GetCommand()
 	let l:LineNum = 1
 	let l:Line = getline(l:LineNum)
 	while l:Line != '--'
-		let l:arg = shellescape(substitute(l:Line, '^--\s*\(.*\)$', '\1', 'g'))
+		let l:arg = shellescape(substitute(l:Line, '^--\s*\(.*\)$', ' \1', 'g'))
 		let l:Command .= l:arg . ' '
 		let l:LineNum = l:LineNum + 1
 		let l:Line = getline(l:LineNum)


### PR DESCRIPTION
vim-mysql-plugin.vim - line 117 - changed "\1" into " \1" (space character added)